### PR TITLE
Djhanse2/questionnaire unit tests

### DIFF
--- a/app/models/question_advice.rb
+++ b/app/models/question_advice.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class QuestionAdvice < ApplicationRecord
-    belongs_to :item
+    belongs_to :item, foreign_key: :question_id
     def self.export_fields(_options)
       QuestionAdvice.columns.map(&:name)
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -44,4 +44,13 @@ FactoryBot.define do
       role { create(:role, :administrator) }
     end
   end
+
+  factory :instructor, class: 'Instructor' do
+    sequence(:name) { |_n| Faker::Name.name.to_s.delete(" \t\r\n").downcase }
+    sequence(:email) { |_n| Faker::Internet.email.to_s }
+    password { 'password' }
+    sequence(:full_name) { |_n| "#{Faker::Name.name}#{Faker::Name.name}".downcase }
+    role { create(:role, :instructor) }
+    institution { create(:institution) }
+  end
 end

--- a/spec/factories/questionnaires.rb
+++ b/spec/factories/questionnaires.rb
@@ -7,8 +7,7 @@ FactoryBot.define do
     private { false }
     min_question_score { 0 }
     max_question_score { 10 }
-    association :instructor
-    association :assignment
+    association :instructor, factory: :instructor
 
     # Trait for questionnaire with questions
     trait :with_questions do

--- a/spec/models/questionnaire_spec.rb
+++ b/spec/models/questionnaire_spec.rb
@@ -2,26 +2,31 @@
 
 require 'rails_helper'
 describe Questionnaire, type: :model do
-
   # Creating dummy objects for the test with the help of let statement
-  let(:role) {Role.create(name: 'Instructor', parent_id: nil, id: 2, default_page_id: nil)}
-  let(:instructor) { Instructor.create(name: 'testinstructor', email: 'test@test.com', full_name: 'Test Instructor', password: '123456', role_id: role.id) }
-  let(:questionnaire) do
-    Questionnaire.create!(
-      id: 1,
-      name: 'abc',
-      private: false,
-      min_question_score: 0,
-      max_question_score: 10,
-      instructor: instructor,
-    )
+  before do
+    allow_any_instance_of(User).to receive(:set_defaults)
   end
-  let(:questionnaire1) { Questionnaire.new name: 'xyz', private: 0, max_question_score: 20, instructor_id: instructor.id }
-  let(:questionnaire2) { Questionnaire.new name: 'pqr', private: 0, max_question_score: 10, instructor_id: instructor.id }
-  let(:question1) { questionnaire.items.build(weight: 1, id: 1, seq: 1, txt: "que 1", question_type: "scale", break_before: true) }
-  let(:question2) { questionnaire.items.build(weight: 10, id: 2, seq: 2, txt: "que 2", question_type: "multiple_choice", break_before: true) }
-
-
+  let(:instructor) { create(:instructor) }
+  let(:questionnaire) do
+        create(:questionnaire,
+          name: 'abc',
+          private: false,
+          min_question_score: 0,
+          max_question_score: 10,
+          instructor: instructor)
+  end
+  let(:questionnaire1) do
+    build(:questionnaire, name: 'xyz', private: 0, max_question_score: 20, instructor: instructor)
+  end
+  let(:questionnaire2) do
+    build(:questionnaire, name: 'pqr', private: 0, max_question_score: 10, instructor: instructor)
+  end
+  let(:question1) do
+    create(:item, questionnaire: questionnaire, weight: 1, seq: 1, txt: 'que 1', question_type: 'scale')
+  end
+  let(:question2) do
+    create(:item, questionnaire: questionnaire, weight: 10, seq: 2, txt: 'que 2', question_type: 'multiple_choice')
+  end
 
   describe '#name' do
     # Test validates the name of the questionnaire
@@ -98,14 +103,14 @@ describe Questionnaire, type: :model do
       questionnaire.min_question_score = 'a'
       expect(questionnaire).not_to be_valid
     end
-
   end
-
 
   describe 'associations' do
     # Test validates the association that a questionnaire comprises of several questions
     it 'has many questions' do
-      expect(questionnaire.items).to include(question1, question2)
+      question1
+      question2
+      expect(questionnaire.items.reload).to include(question1, question2)
     end
   end
 
@@ -113,16 +118,15 @@ describe Questionnaire, type: :model do
     # Test ensures calls from the method copy_questionnaire_details
     it 'allowing calls from copy_questionnaire_details' do
       allow(Questionnaire).to receive(:find).with('1').and_return(questionnaire)
-      allow(Item).to receive(:where).with(questionnaire_id: '1').and_return([Item])
+      allow(Item).to receive(:where).with(questionnaire_id: '1').and_return([question1, question2])
     end
-    
+
     # Test ensures creation of a copy of given questionnaire
     it 'creates a copy of the questionnaire' do
-      instructor.save!
-      questionnaire.save!
-      question1.save!
-      question2.save!
-      copied_questionnaire = Questionnaire.copy_questionnaire_details( { id: questionnaire.id, instructor_id: instructor.id})
+      question1
+      question2
+      copied_questionnaire = Questionnaire.copy_questionnaire_details({ id: questionnaire.id,
+                            instructor_id: instructor.id })
       expect(copied_questionnaire.instructor_id).to eq(questionnaire.instructor_id)
       expect(copied_questionnaire.name).to eq("Copy of #{questionnaire.name}")
       expect(copied_questionnaire.created_at).to be_within(1.second).of(Time.zone.now)
@@ -130,15 +134,141 @@ describe Questionnaire, type: :model do
 
     # Test ensures creation of copy of all the present questionnaire in the database
     it 'creates a copy of all questions belonging to the original questionnaire' do
-      instructor.save!
-      questionnaire.save!
-      question1.save!
-      question2.save!
-      copied_questionnaire = described_class.copy_questionnaire_details({ id: questionnaire.id, instructor_id: instructor.id })
+      question1
+      question2
+      copied_questionnaire = described_class.copy_questionnaire_details({ id: questionnaire.id,
+                              instructor_id: instructor.id })
       expect(copied_questionnaire.items.count).to eq(2)
       expect(copied_questionnaire.items.first.txt).to eq(question1.txt)
       expect(copied_questionnaire.items.second.txt).to eq(question2.txt)
     end
+
+    # Ensures advice rows are duplicated along with copied questions.
+    it 'copies advice rows when original question has advice' do
+      question1
+      QuestionAdvice.insert(
+        {
+          question_id: question1.id,
+          score: 3,
+          advice: 'Good rationale',
+          created_at: Time.zone.now,
+          updated_at: Time.zone.now
+        }
+      )
+
+      copied_questionnaire = described_class.copy_questionnaire_details({ id: questionnaire.id,
+                              instructor_id: instructor.id })
+      copied_question = copied_questionnaire.items.first
+
+      copied_advice = QuestionAdvice.where(question_id: copied_question.id)
+      expect(copied_advice.count).to eq(1)
+      expect(copied_advice.first.score).to eq(3)
+      expect(copied_advice.first.advice).to eq('Good rationale')
+    end
   end
 
+  describe '#symbol' do
+    # Confirms the questionnaire symbol reflects the review type.
+    it 'returns review symbol' do
+      expect(questionnaire.symbol).to eq(:review)
+    end
+  end
+
+  describe '#get_assessments_for' do
+    # Verifies assessments are proxied from the participant reviews collection.
+    it 'returns participant reviews' do
+      reviews = [double('review1'), double('review2')]
+      participant = double('participant', reviews: reviews)
+      expect(questionnaire.get_assessments_for(participant)).to eq(reviews)
+    end
+  end
+
+  describe '#check_for_question_associations' do
+    # Prevents deletion when the questionnaire still has items.
+    it 'raises delete restriction when items exist' do
+      question1
+      questionnaire.items.reload
+      expect { questionnaire.check_for_question_associations }.to raise_error(ActiveRecord::DeleteRestrictionError)
+    end
+
+    # Allows deletion when there are no associated items.
+    it 'does not raise when no items exist' do
+      questionnaire
+      expect { questionnaire.check_for_question_associations }.not_to raise_error
+    end
+  end
+
+  describe '#as_json' do
+    # Ensures JSON serialization includes the instructor field.
+    it 'returns serialized hash with instructor key' do
+      json = questionnaire.as_json
+      expect(json).to include('id', 'name', 'instructor')
+    end
+  end
+
+  describe '#get_weighted_score' do
+    let(:assignment) { double('assignment', id: 42) }
+
+    # Uses the base symbol when no round-specific questionnaire is set.
+    it 'uses base symbol when used_in_round is nil' do
+      aq = double('assignment_questionnaire', used_in_round: nil)
+      allow(AssignmentQuestionnaire).to receive(:find_by).with(assignment_id: 42,
+                                                               questionnaire_id: questionnaire.id).and_return(aq)
+      expect(questionnaire).to receive(:compute_weighted_score).with(:review, assignment, {})
+      questionnaire.get_weighted_score(assignment, {})
+    end
+
+    # Uses a round-specific symbol when used_in_round is provided.
+    it 'uses round specific symbol when used_in_round is present' do
+      aq = double('assignment_questionnaire', used_in_round: 2)
+      allow(AssignmentQuestionnaire).to receive(:find_by).with(assignment_id: 42,
+                                                               questionnaire_id: questionnaire.id).and_return(aq)
+      expect(questionnaire).to receive(:compute_weighted_score).with(:review2, assignment, {})
+      questionnaire.get_weighted_score(assignment, {})
+    end
+  end
+
+  describe '#compute_weighted_score' do
+    let(:assignment) { double('assignment', id: 77) }
+
+    # Handles missing averages by returning zero.
+    it 'returns 0 when average score is nil' do
+      allow(AssignmentQuestionnaire).to receive(:find_by).with(assignment_id: 77).and_return(double('aq',
+                                                                                                    questionnaire_weight: 25))
+      scores = { review: { scores: { avg: nil } } }
+      expect(questionnaire.compute_weighted_score(:review, assignment, scores)).to eq(0)
+    end
+
+    # Computes weighted average when an average score is present.
+    it 'returns weighted average when avg exists' do
+      allow(AssignmentQuestionnaire).to receive(:find_by).with(assignment_id: 77).and_return(double('aq',
+                                                                                                    questionnaire_weight: 25))
+      scores = { review: { scores: { avg: 8 } } }
+      expect(questionnaire.compute_weighted_score(:review, assignment, scores)).to eq(2.0)
+    end
+  end
+
+  describe '#true_false_items?' do
+    # Detects checkbox items as true/false questions.
+    it 'returns true when a checkbox item is present' do
+      allow(questionnaire).to receive(:items).and_return([double('item', type: 'Checkbox')])
+      expect(questionnaire.true_false_items?).to be(true)
+    end
+
+    # Returns false when no checkbox items exist.
+    it 'returns false when no checkbox item is present' do
+      allow(questionnaire).to receive(:items).and_return([double('item', type: 'Criterion')])
+      expect(questionnaire.true_false_items?).to be(false)
+    end
+  end
+
+  describe '#max_possible_score' do
+    # Calculates max possible score from weights and max score.
+    it 'returns sum of item weights multiplied by max_question_score' do
+      question1
+      question2
+
+      expect(questionnaire.max_possible_score.to_i).to eq(110)
+    end
+  end
 end


### PR DESCRIPTION
| Test (spec/it) | Methods targeted in Questionnaire |
| --- | --- |
| `#name` returns the name of the Questionnaire | `validates :name` |
| `#name` Validate presence of name which cannot be blank | `validate_questionnaire`, `validates :name` |
| `#instructor_id` returns the instructor id | `belongs_to :instructor` |
| `#maximum_score` validate maximum score | `validate_questionnaire`, `validates :max_question_score` |
| `#maximum_score` validate maximum score is integer | `validates :max_question_score` |
| `#maximum_score` validate maximum score should be positive | `validate_questionnaire` |
| `#maximum_score` validate maximum score should be bigger than minimum score | `validate_questionnaire` |
| `#minimum_score` validate minimum score | `validate_questionnaire`, `validates :min_question_score` |
| `#minimum_score` validate minimum should be smaller than maximum | `validate_questionnaire` |
| `#minimum_score` validate minimum score is integer | `validates :min_question_score` |
| Associations: `has many questions` | `has_many :items` |
| `.copy_questionnaire_details` allowing calls from copy_questionnaire_details | `.copy_questionnaire_details` |
| `.copy_questionnaire_details` creates a copy of the questionnaire | `.copy_questionnaire_details` |
| `.copy_questionnaire_details` creates a copy of all questions belonging to the original questionnaire | `.copy_questionnaire_details` |
| `.copy_questionnaire_details` copies advice rows when original question has advice | `.copy_questionnaire_details` |
| `#symbol` returns review symbol | `symbol` |
| `#get_assessments_for` returns participant reviews | `get_assessments_for` |
| `#check_for_question_associations` raises delete restriction when items exist | `check_for_question_associations` |
| `#check_for_question_associations` does not raise when no items exist | `check_for_question_associations` |
| `#as_json` returns serialized hash with instructor key | `as_json` |
| `#get_weighted_score` uses base symbol when used_in_round is nil | `get_weighted_score` |
| `#get_weighted_score` uses round specific symbol when used_in_round is present | `get_weighted_score` |
| `#compute_weighted_score` returns 0 when average score is nil | `compute_weighted_score` |
| `#compute_weighted_score` returns weighted average when avg exists | `compute_weighted_score` |
| `#true_false_items?` returns true when a checkbox item is present | `true_false_items?` |
| `#true_false_items?` returns false when no checkbox item is present | `true_false_items?` |
| `#max_possible_score` returns sum of item weights multiplied by max_question_score | `max_possible_score` |


Made a small change that makes the QuestionAdvice association use the correct foreign key. 

The table stores question_id, so belongs_to :item, foreign_key: :question_id tells Rails to look up the related Item by question_id. Without it, Rails expects item_id and the association won’t work correctly.

