### PR TITLE
Removed duplicate Instructor factory

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -3,19 +3,19 @@
 FactoryBot.define do
   factory :student_task do
     assignment { nil }
-    current_stage { "MyString" }
+    current_stage { 'MyString' }
     participant { nil }
-    stage_deadline { "2024-04-15 15:55:54" }
-    topic { "MyString" }
+    stage_deadline { '2024-04-15 15:55:54' }
+    topic { 'MyString' }
   end
 
   factory :join_team_request do
   end
 
   factory :bookmark do
-    url { "MyText" }
-    title { "MyText" }
-    description { "MyText" }
+    url { 'MyText' }
+    title { 'MyText' }
+    description { 'MyText' }
     user_id { 1 }
     topic_id { 1 }
   end
@@ -43,14 +43,5 @@ FactoryBot.define do
     trait :admin do
       role { create(:role, :administrator) }
     end
-  end
-
-  factory :instructor, class: 'Instructor' do
-    sequence(:name) { |_n| Faker::Name.name.to_s.delete(" \t\r\n").downcase }
-    sequence(:email) { |_n| Faker::Internet.email.to_s }
-    password { 'password' }
-    sequence(:full_name) { |_n| "#{Faker::Name.name}#{Faker::Name.name}".downcase }
-    role { create(:role, :instructor) }
-    institution { create(:institution) }
   end
 end


### PR DESCRIPTION
Looking back at my notes, we were seeing an Association Mismatch error and so had created a different type of instructor factory to workaround that issue. But after running a quick test, I verified that the tests now pass. I'm not entirely sure what changed during development that now allows this to pass but it does..... This is the cleaner approach. 